### PR TITLE
[Refactor] 회원가입 폼 함수화, 스키마 분리, 타입 폴더 추가해 관리

### DIFF
--- a/src/app/pages/login/index.tsx
+++ b/src/app/pages/login/index.tsx
@@ -2,37 +2,26 @@
 
 import React from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
-
-type newUserType = {
-    email: string;
-    password: string;
-}
+import { UserLoginType } from "@/types/userType";
+import { logInSchema } from "@/validators/validationSchemas";
 
 const LogIn = ({isVisible}: {isVisible: boolean}) => {
-    // 스키마
-    const schema = z.object({
-        email: z.string().email({ message: "올바른 이메일을 입력해주세요." }),
-        password: z.string().min(6, { message: "비밀번호는 최소 6자 이상이어야 합니다." })
-                         .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/, { message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다." }),
-    });
-
-    const form = useForm<newUserType>({
-        resolver: zodResolver(schema),
+    const form = useForm<UserLoginType>({
+        resolver: zodResolver(logInSchema),
         defaultValues: {
             email: "",
             password: "",
         },
     });
 
-    const onSubmit = (data: newUserType) => {
+    const onSubmit = (data: UserLoginType) => {
         alert(JSON.stringify(data, null, 4));
     };
-    isVisible
+
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className={`flex flex-col justify-center space-y-10 w-1/3 ${isVisible ? "" : "z-10"}`}>
@@ -51,7 +40,7 @@ const LogIn = ({isVisible}: {isVisible: boolean}) => {
                     <FormItem>
                         <FormLabel>Password</FormLabel>
                         <FormControl>
-                            <Input {...field} />
+                            <Input type="password" {...field} />
                         </FormControl>
                         <FormMessage />
                     </FormItem>
@@ -60,7 +49,6 @@ const LogIn = ({isVisible}: {isVisible: boolean}) => {
 
                 <Button type="submit">LogIn</Button>
             </form>
-
         </Form>
     )
 }

--- a/src/app/pages/signup/index.tsx
+++ b/src/app/pages/signup/index.tsx
@@ -1,42 +1,17 @@
 "use client"
 
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-
-type newUserType = {
-    name: string;
-    email: string;
-    tel: string;
-    role: string;
-    password: string;
-    passwordConfirm: string;
-}
+import { UserSignUpType } from "@/types/userType";
+import { signUpSchema } from "@/validators/validationSchemas";
+import InputForm from "@/components/signup/InputForm";
 
 const SignUp = () => {
-    // 스키마
-    const schema = z.object({
-        name: z.string().min(2, { message: "이름은 2글자 이상이어야 합니다." }),
-        email: z.string().email({ message: "올바른 이메일을 입력해주세요." }),
-        tel: z.string().refine(value => value.startsWith("010"), { message: "010으로 시작하는 11자리 숫자를 입력해주세요." })
-                        .refine(value => value.length >= 11, { message: "연락처는 11자리여야 합니다." }),
-        role: z.string().nonempty({ message: "역할을 선택해주세요." }),
-        password: z.string().min(6, { message: "비밀번호는 최소 6자 이상이어야 합니다." })
-                         .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/, { message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다." }),
-        passwordConfirm: z.string()
-                        .min(6, { message: "비밀번호는 최소 6자 이상이어야 합니다." })
-                        .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/, { message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다." })
-    }).refine((data) => data.password === data.passwordConfirm, {
-        path: ["passwordConfirm"],
-        message: "비밀번호가 일치하지 않습니다.",
-    });
-
-    const form = useForm<newUserType>({
-        resolver: zodResolver(schema),
+    const form = useForm<UserSignUpType>({
+        resolver: zodResolver(signUpSchema),
         defaultValues: {
             name: "",
             email: "",
@@ -47,45 +22,18 @@ const SignUp = () => {
         },
     });
 
-    const onSubmit = (data: newUserType) => {
+    const onSubmit = (data: UserSignUpType) => {
         alert(JSON.stringify(data, null, 4));
     };
 
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col space-y-5 h-screen w-1/3 justify-center">
-                <FormField control={form.control} name="name" render={({ field }) => (
-                    <FormItem>
-                        <FormLabel>Name</FormLabel>
-                        <FormControl>
-                            <Input placeholder="홍길동" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <InputForm form={form} id="name" labelName="Name" type="text" placeholder="홍길동"/>
 
-                <FormField control={form.control} name="email" render={({ field }) => (
-                    <FormItem>
-                        <FormLabel>Email</FormLabel>
-                        <FormControl>
-                            <Input placeholder="hello@sparta-devcamp.com" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <InputForm form={form} id="email" labelName="Email" type="email" placeholder="hello@sparta-devcamp.com"/>
 
-                <FormField control={form.control} name="tel" render={({ field }) => (
-                    <FormItem>
-                        <FormLabel>Phone</FormLabel>
-                        <FormControl>
-                            <Input placeholder="01000000000" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <InputForm form={form} id="tel" labelName="Phone" type="text" placeholder="01000000000"/>
 
                 <FormField control={form.control} name="role" render={({ field }) => (
                     <FormItem>
@@ -106,27 +54,9 @@ const SignUp = () => {
                   )}
                 />
 
-                <FormField control={form.control} name="password" render={({ field }) => (
-                    <FormItem>
-                        <FormLabel>Password</FormLabel>
-                        <FormControl>
-                            <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <InputForm form={form} id="password" labelName="Password" type="password" placeholder=""/>
 
-                <FormField control={form.control} name="passwordConfirm" render={({ field }) => (
-                    <FormItem>
-                        <FormLabel>password Confirm</FormLabel>
-                        <FormControl>
-                            <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <InputForm form={form} id="passwordConfirm" labelName="password Confirm" type="password" placeholder=""/>
 
                 <Button type="submit">SignUp</Button>
             </form>

--- a/src/components/signup/InputForm.tsx
+++ b/src/components/signup/InputForm.tsx
@@ -1,0 +1,23 @@
+import { UseFormReturn } from "react-hook-form";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { UserLoginType, UserSignUpType } from "@/types/userType";
+
+type IdType = "name" | "email" | "tel" | "role" | "password" | "passwordConfirm";
+
+const InputForm = ({form, id, labelName, type, placeholder}: {form: UseFormReturn<UserSignUpType>, id: IdType, labelName: string, type: string, placeholder: string }) => {
+    return (
+        <FormField control={form.control} name={id} render={({ field }) => (
+            <FormItem>
+                <FormLabel>{labelName}</FormLabel>
+                <FormControl>
+                    <Input type={type} placeholder={placeholder} {...field} />
+                </FormControl>
+                <FormMessage />
+            </FormItem>
+          )}
+        />
+    )
+}
+
+export default InputForm;

--- a/src/types/userType.d.ts
+++ b/src/types/userType.d.ts
@@ -1,0 +1,11 @@
+export type UserLoginType = {
+    email: string;
+    password: string;
+}
+
+export type UserSignUpType = UserLoginType & {
+    name: string;
+    tel: string;
+    role: string;
+    passwordConfirm: string;
+};

--- a/src/validators/validationSchemas.ts
+++ b/src/validators/validationSchemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const logInSchema = z.object({
+    email: z.string().email({ message: "올바른 이메일을 입력해주세요." }),
+    password: z.string().min(6, { message: "비밀번호는 최소 6자 이상이어야 합니다." })
+                     .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/, { message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다." }),
+});
+
+export const signUpSchema = logInSchema.extend({
+    name: z.string().min(2, { message: "이름은 2글자 이상이어야 합니다." }),
+    tel: z.string().refine(value => value.startsWith("010"), { message: "010으로 시작하는 11자리 숫자를 입력해주세요." })
+                    .refine(value => value.length >= 11, { message: "연락처는 11자리여야 합니다." }),
+    role: z.string().nonempty({ message: "역할을 선택해주세요." }),
+    passwordConfirm: z.string()
+                    .min(6, { message: "비밀번호는 최소 6자 이상이어야 합니다." })
+                    .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/, { message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다." })
+}).refine((data) => data.password === data.passwordConfirm, {
+    path: ["passwordConfirm"],
+    message: "비밀번호가 일치하지 않습니다.",
+});


### PR DESCRIPTION
## 작업 내용
1. 회원가입 폼 중복되는 코드 함수화 (/components/signup/inputForm.tsx)

2. 스키마 파일 분리
로그인 스키마 생성 후 extend 사용해 상속 받아 회원가입 스키마 생성 (/validators/validationSchemas.ts)

3. 타입 폴더 추가하여 관리
로그인, 회원가입 생성, 회원가입의 경우 로그인 상속 받고 있음
(/types/userType.d.ts)